### PR TITLE
Fully statically linked skyscope binary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,8 @@ build:ci-windows --crosstool_top=@rules_haskell_ghc_windows_amd64//:cc_toolchain
 
 # This project uses a GHC provisioned via nix.
 # We need to use the rules_haskell nix toolchain accordingly:
-build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
-run --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
+build --host_platform=//backend:regular_executable --incompatible_enable_cc_toolchain_resolution
+run --host_platform=//backend:regular_executable --incompatible_enable_cc_toolchain_resolution
 
 # test environment does not propagate locales by default
 # some tests reads files written in UTF8, we need to propagate the correct

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -76,6 +76,7 @@ stack_snapshot(
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
 
+# TODO[AH] Replace this by global Nix configuration for appropriate Nix cache.
 static_nixopts = ["--builders", "@/etc/nix/machines", "-j0"]
 
 nixpkgs_cc_configure(
@@ -91,6 +92,7 @@ load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
     attribute_path = "",
+    # TODO[AH] Upstream and expose through a Nix cache.
     nix_file_content = """\
 with import <nixpkgs> { config = {}; overlays = []; };
 haskell.compiler.ghc902.override {

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -76,7 +76,17 @@ stack_snapshot(
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
 
-nixpkgs_cc_configure(repository = "@nixpkgs")
+nixpkgs_cc_configure(
+    repository = "@nixpkgs",
+    nix_file_content = """\
+with import <nixpkgs> { config = {}; overlays = []; };
+buildEnv {
+  name = "bazel-cc-toolchain";
+  paths = [ pkgsMusl.stdenv.cc pkgsMusl.binutils ];
+  passthru = { isClang = pkgsMusl.stdenv.cc.isClang; };
+}
+""",
+)
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_python_configure")
 
@@ -85,16 +95,26 @@ nixpkgs_python_configure(repository = "@nixpkgs")
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
-    attribute_path = "ghc",
+    attribute_path = "",
+    nix_file_content = """\
+with import <nixpkgs> {};
+pkgsMusl.haskell.compiler.ghc902.override { enableRelocatedStaticLibs = true; enableShared = false; }
+""",
     repository = "@nixpkgs",
     version = "9.0.2",
+    static_runtime = True,
+    fully_static_link = True,
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 
 nixpkgs_package(
     name = "nixpkgs_zlib",
-    attribute_path = "zlib",
+    nix_file_content = """\
+with import <nixpkgs> { config = {}; overlays = []; };
+( pkgsMusl.zlib.override { static=true; shared=false; }
+).overrideAttrs (_:{ dontDisableStatic=true; })
+""",
     repository = "@nixpkgs",
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_tweag_rules_nixpkgs",
-    sha256 = "1f3d86577eb1b85881f60c9eb1eb420c64d2ec8b9c951dbd66394db20cb5ddb1",
-    strip_prefix = "rules_nixpkgs-d28e07001f2c2386162cb51964f02f6c9b67628a",
-    urls = ["https://github.com/tweag/rules_nixpkgs/archive/d28e07001f2c2386162cb51964f02f6c9b67628a.tar.gz"],
+    sha256 = "9e3898a33c5f21f634aa9e2d45620e7c4b6d54d16d473571a891193bbd4725ca",
+    strip_prefix = "rules_nixpkgs-0c1f8f5470c7f292b7620762e224f53d837929d3",
+    urls = ["https://github.com/tweag/rules_nixpkgs/archive/0c1f8f5470c7f292b7620762e224f53d837929d3.tar.gz"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:repositories.bzl", "rules_nixpkgs_dependencies")
@@ -97,10 +97,21 @@ load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 haskell_register_ghc_nixpkgs(
     attribute_path = "",
     nix_file_content = """\
-with import <nixpkgs> {};
-pkgsMusl.haskell.compiler.ghc902.override { enableRelocatedStaticLibs = true; enableShared = false; }
+let
+  pkgs = import <nixpkgs> {};
+  static-haskell-nix = import <static-haskell-nix> { normalPkgs = pkgs; };
+  inherit (static-haskell-nix) pkgsWithArchiveFiles;
+in
+pkgsWithArchiveFiles.haskell.compiler.ghc902.override {
+  enableRelocatedStaticLibs = true;
+  enableShared = false;
+}
 """,
-    repository = "@nixpkgs",
+    repositories = {
+        "nixpkgs": "@nixpkgs",
+        "static-haskell-nix": "@static-haskell-nix//:survey/default.nix",
+    },
+    nixopts = ["--builders", "@/etc/nix/machines", "-j0"],
     version = "9.0.2",
     static_runtime = True,
     fully_static_link = True,
@@ -129,6 +140,14 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_local_repository")
 nixpkgs_local_repository(
     name = "nixpkgs",
     nix_flake_lock_file = "//:flake.lock",
+)
+
+load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_http_repository")
+
+nixpkgs_http_repository(
+    name = "static-haskell-nix",
+    url = "https://github.com/nh2/static-haskell-nix/archive/bd66b86b72cff4479e1c76d5916a853c38d09837.tar.gz",
+    strip_prefix = "static-haskell-nix-bd66b86b72cff4479e1c76d5916a853c38d09837",
 )
 
 nixpkgs_package(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -78,19 +78,19 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
 
 nixpkgs_cc_configure(
     name = "local_config_cc_regular",
-    repository = "@nixpkgs",
     exec_constraints = ["@//backend:regular_linking"],
+    repository = "@nixpkgs",
     target_constraints = ["@//backend:regular_linking"],
 )
 
 # TODO[AH] Replace this by global Nix configuration for appropriate Nix cache.
-static_nixopts = [] #["--builders", "@/etc/nix/machines", "-j0"]
+static_nixopts = []  #["--builders", "@/etc/nix/machines", "-j0"]
 
 nixpkgs_cc_configure(
     name = "local_config_cc_static",
-    repository = "@static-nixpkgs",
-    nixopts = static_nixopts,
     exec_constraints = ["@//backend:fully_static_linking"],
+    nixopts = static_nixopts,
+    repository = "@static-nixpkgs",
     target_constraints = ["@//backend:fully_static_linking"],
 )
 
@@ -103,15 +103,17 @@ load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 haskell_register_ghc_nixpkgs(
     name = "rules_haskell_regular",
     attribute_path = "ghc",
-    repository = "@nixpkgs",
-    version = "9.0.2",
     exec_constraints = ["@//backend:regular_linking"],
+    repository = "@nixpkgs",
     target_constraints = ["@//backend:regular_linking"],
+    version = "9.0.2",
 )
 
 haskell_register_ghc_nixpkgs(
     name = "rules_haskell_static",
     attribute_path = "",
+    exec_constraints = ["@//backend:fully_static_linking"],
+    fully_static_link = True,
     # TODO[AH] Upstream and expose through a Nix cache.
     nix_file_content = """\
 with import <nixpkgs> { config = {}; overlays = []; };
@@ -120,13 +122,11 @@ haskell.compiler.ghc902.override {
   enableShared = false;
 }
 """,
-    repository = "@static-nixpkgs",
     nixopts = static_nixopts,
-    version = "9.0.2",
+    repository = "@static-nixpkgs",
     static_runtime = True,
-    fully_static_link = True,
-    exec_constraints = ["@//backend:fully_static_linking"],
     target_constraints = ["@//backend:fully_static_linking"],
+    version = "9.0.2",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
@@ -140,8 +140,8 @@ nixpkgs_package(
 nixpkgs_package(
     name = "nixpkgs_zlib.static",
     attribute_path = "zlib.static",
-    repository = "@static-nixpkgs",
     nixopts = static_nixopts,
+    repository = "@static-nixpkgs",
 )
 
 nixpkgs_package(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -76,12 +76,22 @@ stack_snapshot(
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
 
+nixpkgs_cc_configure(
+    name = "local_config_cc_regular",
+    repository = "@nixpkgs",
+    exec_constraints = ["@//backend:regular_linking"],
+    target_constraints = ["@//backend:regular_linking"],
+)
+
 # TODO[AH] Replace this by global Nix configuration for appropriate Nix cache.
-static_nixopts = ["--builders", "@/etc/nix/machines", "-j0"]
+static_nixopts = [] #["--builders", "@/etc/nix/machines", "-j0"]
 
 nixpkgs_cc_configure(
+    name = "local_config_cc_static",
     repository = "@static-nixpkgs",
     nixopts = static_nixopts,
+    exec_constraints = ["@//backend:fully_static_linking"],
+    target_constraints = ["@//backend:fully_static_linking"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_python_configure")
@@ -91,6 +101,16 @@ nixpkgs_python_configure(repository = "@nixpkgs")
 load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 
 haskell_register_ghc_nixpkgs(
+    name = "rules_haskell_regular",
+    attribute_path = "ghc",
+    repository = "@nixpkgs",
+    version = "9.0.2",
+    exec_constraints = ["@//backend:regular_linking"],
+    target_constraints = ["@//backend:regular_linking"],
+)
+
+haskell_register_ghc_nixpkgs(
+    name = "rules_haskell_static",
     attribute_path = "",
     # TODO[AH] Upstream and expose through a Nix cache.
     nix_file_content = """\
@@ -105,12 +125,20 @@ haskell.compiler.ghc902.override {
     version = "9.0.2",
     static_runtime = True,
     fully_static_link = True,
+    exec_constraints = ["@//backend:fully_static_linking"],
+    target_constraints = ["@//backend:fully_static_linking"],
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 
 nixpkgs_package(
     name = "nixpkgs_zlib",
+    attribute_path = "zlib",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "nixpkgs_zlib.static",
     attribute_path = "zlib.static",
     repository = "@static-nixpkgs",
     nixopts = static_nixopts,
@@ -133,6 +161,19 @@ nixpkgs_package(
         }
     """,
     repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "sqlite.dev.static",
+    build_file = "//backend:sqlite.BUILD.bazel",
+    nix_file_content = """
+        let pkgs = import <nixpkgs> { };
+        in pkgs.buildEnv {
+          name = "sqlite";
+          paths = [ pkgs.sqlite.dev pkgs.sqlite.out ];
+        }
+    """,
+    repository = "@static-nixpkgs",
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_local_repository")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -76,16 +76,11 @@ stack_snapshot(
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_git_repository")
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_cc_configure")
 
+static_nixopts = ["--builders", "@/etc/nix/machines", "-j0"]
+
 nixpkgs_cc_configure(
-    repository = "@nixpkgs",
-    nix_file_content = """\
-with import <nixpkgs> { config = {}; overlays = []; };
-buildEnv {
-  name = "bazel-cc-toolchain";
-  paths = [ pkgsMusl.stdenv.cc pkgsMusl.binutils ];
-  passthru = { isClang = pkgsMusl.stdenv.cc.isClang; };
-}
-""",
+    repository = "@static-nixpkgs",
+    nixopts = static_nixopts,
 )
 
 load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_python_configure")
@@ -97,21 +92,14 @@ load("@rules_haskell//haskell:nixpkgs.bzl", "haskell_register_ghc_nixpkgs")
 haskell_register_ghc_nixpkgs(
     attribute_path = "",
     nix_file_content = """\
-let
-  pkgs = import <nixpkgs> {};
-  static-haskell-nix = import <static-haskell-nix> { normalPkgs = pkgs; };
-  inherit (static-haskell-nix) pkgsWithArchiveFiles;
-in
-pkgsWithArchiveFiles.haskell.compiler.ghc902.override {
+with import <nixpkgs> { config = {}; overlays = []; };
+haskell.compiler.ghc902.override {
   enableRelocatedStaticLibs = true;
   enableShared = false;
 }
 """,
-    repositories = {
-        "nixpkgs": "@nixpkgs",
-        "static-haskell-nix": "@static-haskell-nix//:survey/default.nix",
-    },
-    nixopts = ["--builders", "@/etc/nix/machines", "-j0"],
+    repository = "@static-nixpkgs",
+    nixopts = static_nixopts,
     version = "9.0.2",
     static_runtime = True,
     fully_static_link = True,
@@ -121,12 +109,9 @@ load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_package")
 
 nixpkgs_package(
     name = "nixpkgs_zlib",
-    nix_file_content = """\
-with import <nixpkgs> { config = {}; overlays = []; };
-( pkgsMusl.zlib.override { static=true; shared=false; }
-).overrideAttrs (_:{ dontDisableStatic=true; })
-""",
-    repository = "@nixpkgs",
+    attribute_path = "zlib.static",
+    repository = "@static-nixpkgs",
+    nixopts = static_nixopts,
 )
 
 nixpkgs_package(
@@ -142,12 +127,10 @@ nixpkgs_local_repository(
     nix_flake_lock_file = "//:flake.lock",
 )
 
-load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_http_repository")
-
-nixpkgs_http_repository(
-    name = "static-haskell-nix",
-    url = "https://github.com/nh2/static-haskell-nix/archive/bd66b86b72cff4479e1c76d5916a853c38d09837.tar.gz",
-    strip_prefix = "static-haskell-nix-bd66b86b72cff4479e1c76d5916a853c38d09837",
+nixpkgs_local_repository(
+    name = "static-nixpkgs",
+    nix_file = "//:static-nixpkgs.nix",
+    nix_file_deps = ["//:flake.lock"],
 )
 
 nixpkgs_package(

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -62,6 +62,7 @@ haskell_binary(
         "@stackage//:warp",
         "@stackage//:zlib",
     ],
+    features = ["fully_static_link"],
 )
 
 cc_library(

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -1,5 +1,36 @@
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary", "haskell_toolchain_library")
 
+constraint_setting(
+    name = "executable_linking",
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "fully_static_linking",
+    constraint_setting = ":executable_linking",
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "static_executable",
+    constraint_values = [":fully_static_linking"],
+    parents = ["@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"],
+    visibility = ["//visibility:public"],
+)
+
+constraint_value(
+    name = "regular_linking",
+    constraint_setting = ":executable_linking",
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "regular_executable",
+    constraint_values = [":regular_linking"],
+    parents = ["@io_tweag_rules_nixpkgs//nixpkgs/platforms:host"],
+    visibility = ["//visibility:public"],
+)
+
 haskell_toolchain_library(name = "base")
 
 haskell_binary(
@@ -63,7 +94,10 @@ haskell_binary(
         "@stackage//:warp",
         "@stackage//:zlib",
     ],
-    features = ["fully_static_link"],
+    features = select({
+        "@//backend:regular_linking": [],
+        "@//backend:fully_static_linking": ["fully_static_link"],
+    }),
 )
 
 copts = [
@@ -84,5 +118,8 @@ cc_library(
     srcs = [":src/import.cpp"],
     copts = copts,
     linkstatic = True,
-    deps = ["@sqlite.dev"],
+    deps = select({
+        "@//backend:regular_linking": ["@sqlite.dev"],
+        "@//backend:fully_static_linking": ["@sqlite.dev.static//:sqlite.dev"],
+    }),
 )

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -52,6 +52,10 @@ haskell_binary(
         "//frontend:src/theme.css",
         "//backend:src/schema.sql",
     ],
+    features = select({
+        "@//backend:regular_linking": [],
+        "@//backend:fully_static_linking": ["fully_static_link"],
+    }),
     ghcopts = [
         "-O2",
         "-Wall",
@@ -94,10 +98,6 @@ haskell_binary(
         "@stackage//:warp",
         "@stackage//:zlib",
     ],
-    features = select({
-        "@//backend:regular_linking": [],
-        "@//backend:fully_static_linking": ["fully_static_link"],
-    }),
 )
 
 copts = [

--- a/backend/sqlite.BUILD.bazel
+++ b/backend/sqlite.BUILD.bazel
@@ -2,7 +2,15 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "sqlite.dev",
-    srcs = glob(["lib/*.so*"]),
+    srcs = select({
+        "@//backend:regular_linking": glob(["lib/*.so*"]),
+        "@//backend:fully_static_linking": [
+            # No need to link anything for sqlite when building a fully static executable.
+            # The direct-sqlite Haskell library already links against it so we can just
+            # assume the appropriate symbols will already be available in the executable
+            # and let the linker sort it out.
+        ],
+    }),
     hdrs = glob(["include/*.h"]),
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],

--- a/backend/zlib.BUILD.bazel
+++ b/backend/zlib.BUILD.bazel
@@ -7,7 +7,10 @@ filegroup(
 )
 cc_library(
     name = "zlib",
-    srcs = ["@nixpkgs_zlib//:lib"],
+    srcs = select({
+        "@//backend:regular_linking": ["@nixpkgs_zlib//:lib"],
+        "@//backend:fully_static_linking": ["@nixpkgs_zlib.static//:lib"],
+    }),
     hdrs = [":include"],
     strip_include_prefix = "include",
     visibility = ["//visibility:public"],

--- a/static-nixpkgs.nix
+++ b/static-nixpkgs.nix
@@ -1,0 +1,20 @@
+{...}@args:
+let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  nixpkgs =
+    let
+      src = lock.nodes.nixpkgs.locked;
+    in
+    assert src.type == "github";
+    fetchTarball {
+      url = "https://github.com/${src.owner}/${src.repo}/archive/${src.rev}.tar.gz";
+      sha256 = src.narHash;
+    };
+  normalPkgs = import nixpkgs args;
+  static-haskell-nix =
+    fetchTarball {
+      url = "https://github.com/nh2/static-haskell-nix/archive/bd66b86b72cff4479e1c76d5916a853c38d09837.tar.gz";
+      sha256 = "sha256:0rnsxaw7v27znsg9lgqk1i4007ydqrc8gfgimrmhf24lv6galbjh";
+    };
+in
+(import "${static-haskell-nix}/survey" { inherit normalPkgs; }).pkgsWithArchiveFiles


### PR DESCRIPTION
This uses rules_haskell's capability for fully static linking together with static libraries and an appropriate GHC provided by [static-haskell-nix](https://github.com/nh2/static-haskell-nix) and patched as described in [this blog post](https://www.tweag.io/blog/2020-09-30-bazel-static-haskell/).

A build on Linux confirms that the resulting library is fully static and is functional.
```
$ file bazel-bin/backend/skyscope
bazel-bin/backend/skyscope: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```

What's missing to be able to merge this is (at least) to have the appropriate GHC, GCC, zlib, etc. in a Nix cache.

Warning: If you test this locally this will build GHC via Nix. You can use a remote builder configured in `/etc/nix/machines` to speed it up.

cc @nh2 @jonathanlking
