### PR TITLE
Escape graphviz node names and handle `bazel version` parsing failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ in your browser console.
 | `SKYSCOPE_DEBUG`     | Execution tracing is enabled for the wrapper scripts when this variable is set. |
 | `SKYSCOPE_FORMAT_JS` | Set this to the path of a [Javascript file](https://github.com/tweag/skyscope/blob/master/frontend/src/format.js) to override the embedded node formatting. |
 | `SKYSCOPE_THEME_CSS` | Set this to the path of a [CSS file](https://github.com/tweag/skyscope/blob/master/frontend/src/theme.css) to override the embedded theme. |
+| `SKYSCOPE_BAZEL_BIN` | Use this bazel binary instead of whatever is found in your PATH. |
 
 ### General Purpose Use
 

--- a/backend/src/Main.hs
+++ b/backend/src/Main.hs
@@ -106,7 +106,7 @@ importWorkspace args = importNew Nothing $ \dbPath -> do
             ] ->
           "detailed" <$ setEnv "SKYSCOPE_LEGACY_BAZEL" "1"
         | otherwise -> pure "deps"
-      Nothing -> error "unable to determine bazel version"
+      Nothing -> "deps" <$ putStrLn "unable to determine bazel version, assuming latest"
   withStdinFrom "bazel" ["dump", "--skyframe=" <> dumpSkyframeOpt] (Import.importSkyframe dbPath)
 
 parseImportArgs :: [String] -> (String, String)

--- a/backend/src/Render.hs
+++ b/backend/src/Render.hs
@@ -137,7 +137,7 @@ renderGraph database dbPath nodeStates = do
           label = nodeType <> "\\n" <> truncatedNodeData
           nodeState = Map.lookup nodeHash nodeStates
           hidden = nodeState == Nothing
-       in "    node_" <> nodeHash
+       in "    \"node_" <> nodeHash <> "\""
             <> graphvizAttributes
               [ ("tooltip", truncatedNodeData),
                 ("class", Text.pack $ fromMaybe "" $ show <$> nodeState),
@@ -151,7 +151,7 @@ renderGraph database dbPath nodeStates = do
 
     graphvizEdge :: [(Text, Text)] -> Edge -> Text
     graphvizEdge attrs (Edge _ source target) =
-      "    node_" <> source <> " -> node_" <> target
+      "    \"node_" <> source <> "\" -> \"node_" <> target <> "\""
         <> graphvizAttributes (attrs ++ [("id", source <> "_" <> target)])
 
     graphvizAttributes :: [(Text, Text)] -> Text


### PR DESCRIPTION
This pull request addresses a couple of issues:
* #113
* #114 