### PR TITLE
Import config after skyframe to avoid graph invalidation

### DIFF
--- a/backend/src/Main.hs
+++ b/backend/src/Main.hs
@@ -121,10 +121,6 @@ importWorkspace args = do
             $ \_ (Just bazelStdout) _ _ -> f bazelStdout dbPath
 
     when (isNothing existingImport) $ do
-      putStrLn "importing extra context for configs"
-      hashes <- withBazel ["config"] Import.listConfigs
-      for_ hashes $ \hash -> withBazel ["config", Text.unpack hash] (Import.importConfig hash)
-
       dumpSkyframeOpt <-
         getBazelVersion >>= \case
           Just version
@@ -139,6 +135,10 @@ importWorkspace args = do
 
       bazel <- getBazelPath
       withStdinFrom bazel ["dump", "--skyframe=" <> dumpSkyframeOpt] (Import.importSkyframe dbPath)
+
+      putStrLn "importing extra context for configs"
+      hashes <- withBazel ["config"] Import.listConfigs
+      for_ hashes $ \hash -> withBazel ["config", Text.unpack hash] (Import.importConfig hash)
 
     when (queryExpr /= "") $ do
       putStrLn "importing extra context for targets"


### PR DESCRIPTION
In some Bazel repositories, running `bazel config` seems to invalidate part of the skyframe graph and cause it to be cleared. Perform the config import after the skyframe import to ensure we are not missing action nodes.